### PR TITLE
[HUST CSE]修改printf类型不匹配的问题

### DIFF
--- a/src/rp2_common/pico_malloc/pico_malloc.c
+++ b/src/rp2_common/pico_malloc/pico_malloc.c
@@ -39,7 +39,7 @@ void *__wrap_malloc(size_t size) {
 #endif
 #if PICO_DEBUG_MALLOC
     if (!rc || ((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) {
-        printf("malloc %d %p->%p\n", (uint) size, rc, ((uint8_t *) rc) + size);
+        printf("malloc %u %p->%p\n", (uint) size, rc, ((uint8_t *) rc) + size);
     }
 #endif
     check_alloc(rc, size);
@@ -56,7 +56,7 @@ void *__wrap_calloc(size_t count, size_t size) {
 #endif
 #if PICO_DEBUG_MALLOC
     if (!rc || ((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) {
-        printf("calloc %d %p->%p\n", (uint) (count * size), rc, ((uint8_t *) rc) + size);
+        printf("calloc %u %p->%p\n", (uint) (count * size), rc, ((uint8_t *) rc) + size);
     }
 #endif
     check_alloc(rc, size);

--- a/tools/pioasm/python_output.cpp
+++ b/tools/pioasm/python_output.cpp
@@ -114,7 +114,7 @@ struct python_output : public output_format {
                 if (it != jmp_labels.end()) {
                     fprintf(out, "    label(\"%s\")\n", it->second.c_str());
                 }
-                fprintf(out, "    %s # %d\n", disassemble(jmp_labels, inst, program.sideset_bits_including_opt.get(), program.sideset_opt).c_str(), i);
+                fprintf(out, "    %s # %u\n", disassemble(jmp_labels, inst, program.sideset_bits_including_opt.get(), program.sideset_opt).c_str(), i);
                 if (i == program.wrap) {
                     fprintf(out, "    wrap()\n");
                 }


### PR DESCRIPTION
### 为什么提交这份PR (why to submit this PR)

在fprintf输出语句中uint类型的变量对应的说明符为%d，两者并不匹配。
此处给出文件路径：


1. src\rp2_common\pico_malloc\pico_malloc.c
2. tools\pioasm\python_output.cpp

查看源码：
`printf("malloc %d %p->%p\n", (uint) size, rc, ((uint8_t *) rc) + size);`
`printf("calloc %d %p->%p\n", (uint) (count * size), rc, ((uint8_t *) rc) + size);`
`fprintf(out, "    %s # %d\n", disassemble(jmp_labels, inst, program.sideset_bits_including_opt.get(), program.sideset_opt).c_str(), i);`

### 你的解决方案是什么 (what is your solution)
将%d改成%u，与uint类型的变量匹配。修改后代码如下：

`printf("malloc %u %p->%p\n", (uint) size, rc, ((uint8_t *) rc) + size);`
`printf("calloc %u %p->%p\n", (uint) (count * size), rc, ((uint8_t *) rc) + size);`
`fprintf(out, "    %s # %u\n", disassemble(jmp_labels, inst, program.sideset_bits_including_opt.get(), program.sideset_opt).c_str(), i);`